### PR TITLE
new: add methods for product attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var RestClient = require('./lib/rest_client').RestClient;
 var categories = require('./lib/categories');
 var products = require('./lib/products');
 var productMedia = require('./lib/product_media');
+var productAttributes = require('./lib/product_attributes');
 
 const MAGENTO_API_VERSION = 'V1';
 
@@ -16,6 +17,7 @@ module.exports.Magento2Client = function (options) {
 
     instance.categories = categories(client);
     instance.products = products(client);
+    instance.productAttributes = productAttributes(client);
     instance.productMedia = productMedia(client);
 
     return instance;

--- a/lib/product_attributes.js
+++ b/lib/product_attributes.js
@@ -1,0 +1,32 @@
+var util = require('util');
+
+module.exports = function (restClient) {
+    var module = {};
+
+    module.list = function (searchCriteria) {
+        var query = 'searchCriteria=' + searchCriteria;
+        var endpointUrl = util.format('/products/attributes?%s', query);
+        return restClient.get(endpointUrl);
+    }
+
+    module.get = function (attributeCode) {
+        var endpointUrl = util.format('/products/attributes/%s', attributeCode)
+        return restClient.get(endpointUrl);
+    }
+
+    module.create = function (attributeAttributes) {
+        return restClient.post('/products/attributes', attributeAttributes);
+    }
+
+    module.update = function (attributeCode, attributeAttributes) {
+        var endpointUrl = util.format('/products/attributes/%s', attributeCode);
+        return restClient.put(endpointUrl, attributeAttributes);
+    }
+
+    module.delete = function (attributeCode) {
+        var endpointUrl = util.format('/products/attributes/%s', attributeCode);
+        return restClient.delete(endpointUrl);
+    }
+
+    return module;
+}

--- a/test/integration/product_attributes.integration.test.js
+++ b/test/integration/product_attributes.integration.test.js
@@ -1,0 +1,85 @@
+var chai = require('chai');
+var credentials = require('../config');
+var assert = chai.assert;
+
+var Magento2Client = require('../../index').Magento2Client;
+
+suite('products attritbutes tests', function () {
+    var client;
+
+    before(function () {
+        client = Magento2Client(credentials);
+    });
+
+    test('list product attributes test', function (done) {
+        client.productAttributes.list()
+            .then(function (productAttributes) {
+                assert.isTrue(productAttributes.items.length > 0);
+            })
+            .then(done, done);
+    });
+
+    test('get product attribute test', function (done) {
+        client.productAttributes.get('swatch_image')
+            .then(function (productAttributes) {
+                assert.isNotNull(productAttributes);
+            })
+            .then(done, done);
+    });
+
+    test('create product attribute test', function (done) {
+        var newProductAttribute = {
+            'attribute': {
+                'attribute_code': 'test123',
+                'frontend_input': 'select',
+                'is_required': false,
+                'frontend_labels': [{
+                    'store_id': 0,
+                    'label': 'Test Front End Store'
+                }]
+            }
+        };
+        client.productAttributes.create(newProductAttribute)
+            .then(function (result) {
+                assert.isNotNull(result);
+            })
+            .then(done, done);
+    });
+
+    test('update product attribute test', function (done) {
+        var productAttributeUpdate = {
+            'attribute': {
+                'attribute_id': undefined,
+                'attribute_code': 'test123',
+                'is_required': false,
+                'frontend_input': 'select',
+                'frontend_labels': [{
+                    'store_id': 0,
+                    'label': 'Test Front End Store Updated'
+                }]
+            }
+        };
+        client.productAttributes.get('test123')
+            .then(function (productAttributes) {
+                var attributeId = productAttributes.attributeId;
+                productAttributeUpdate.attribute['attribute_id'] = attributeId;
+                return;
+            })
+            .then(function () {
+                return client.productAttributes.update('test123', productAttributeUpdate);
+            })
+            .then(function (result) {
+                assert.isNotNull(result);
+                assert.equal(result.defaultFrontendLabel, 'Test Front End Store Updated');
+            })
+            .then(done, done);
+    });
+
+    test('delete product attribute test', function (done) {
+        client.productAttributes.delete('test123')
+            .then(function (result) {
+                assert.isTrue(result);
+            })
+            .then(done, done);
+    })
+});


### PR DESCRIPTION
This adds an additional API endpoint for product attributes.

I did my best to match existing coding styles. The only major difference is one of the tests needs to pull the `attributeId` of the existing attribute before it can update it.